### PR TITLE
Feature/submode

### DIFF
--- a/MWO_SyncDrop_StreamlabsSystem.py
+++ b/MWO_SyncDrop_StreamlabsSystem.py
@@ -16,7 +16,7 @@ ScriptName = "Sync-Drop Countdown Script"
 Website = "https://www.dimensionv.de"
 Description = "Initiates a countdown on chat for sync-dropping, using the !syncdrop command"
 Creator = "Karubian"
-Version = "1.1.0"
+Version = "1.2.0"
 
 #---------------------------------------
 # Set Variables
@@ -31,6 +31,8 @@ countDownTime = 5
 useNA = True
 useEU = True
 useOC = True
+
+useSubMode = True
 
 effectiveLaunchText = launchText
 effectiveTime = countDownTime
@@ -86,6 +88,7 @@ def Tick():
 #---------------------------------------
 def ReloadSettings(jsonData):
     global launchText
+    global useSubMode
     global useBoth
     global countDownTime
     global useNA
@@ -99,10 +102,12 @@ def ReloadSettings(jsonData):
 
     if("launchText" in parsedData):
         launchText = parsedData["launchText"]
+    if("useSubMode" in parsedData):
+        useSubMode = parsedData["launchText"]
     if("useBoth" in parsedData):
         useBoth = parsedData["useBoth"]
     if("countDownTime" in parsedData):
-        countDownTime = parsedData["countDownTime"]
+        countDownTime = parsedData["useSubMode"]
     if("useNA" in parsedData):
       useNA = parsedData["useNA"]
     if("useEU" in parsedData):
@@ -151,7 +156,10 @@ def checkPermissionToRun(data):
     return result
  
 def runCountDown(count, includeEU, includeNA, includeOC):
-    sendMessage("Initiating sync-drop with the following regions included:")
+	if(useSubMode and isFromTwitch):
+		Parent.sendTwitchMessage("/subscribers");
+		
+	sendMessage("Initiating sync-drop with the following regions included:")
 
     if(includeNA):
         sendMessage("North America")
@@ -167,6 +175,10 @@ def runCountDown(count, includeEU, includeNA, includeOC):
         time.sleep(1.0)
 
     sendMessage(launchText)
+    
+	if(useSubMode and isFromTwitch):
+		Parent.sendTwitchMessage("/subscribersoff");
+    
     return
 
 def showHelp():

--- a/MWO_SyncDrop_StreamlabsSystem.py
+++ b/MWO_SyncDrop_StreamlabsSystem.py
@@ -156,10 +156,10 @@ def checkPermissionToRun(data):
     return result
  
 def runCountDown(count, includeEU, includeNA, includeOC):
-	if(useSubMode and isFromTwitch):
-		Parent.sendTwitchMessage("/subscribers");
+    if(useSubMode and isFromTwitch):
+        Parent.sendTwitchMessage("/subscribers")
 		
-	sendMessage("Initiating sync-drop with the following regions included:")
+    sendMessage("Initiating sync-drop with the following regions included:")
 
     if(includeNA):
         sendMessage("North America")
@@ -176,8 +176,8 @@ def runCountDown(count, includeEU, includeNA, includeOC):
 
     sendMessage(launchText)
     
-	if(useSubMode and isFromTwitch):
-		Parent.sendTwitchMessage("/subscribersoff");
+    if(useSubMode and isFromTwitch):
+       Parent.sendTwitchMessage("/subscribersoff")
     
     return
 

--- a/UI_config.json
+++ b/UI_config.json
@@ -14,6 +14,13 @@
         "tooltip": "Text send to the chat when the sync drop shall begin, and people should hit the launch button.",
         "group": "General"
     },
+    "useSubMode": {
+        "type": "checkbox",
+        "label": "Use subscription mode on Twitch during countdown",
+        "value": true,
+        "tooltip": "Enables subscription mode on Twitch, effectively silencing every non-subscriber.",
+        "group": "General"
+    },
     "useBoth": {
         "type": "checkbox",
         "label": "Always use both chat systems",


### PR DESCRIPTION
It is now possible to enable a forced subscribers mode for the duration
the syncdrop countdown.
This effectively silences the channel for all except the subscriber, until
the countdown is over, which can be a good thing on channels with lots of chatter going on.