### PR TITLE
The included regions are now send in a single message during count down.

### DIFF
--- a/MWO_SyncDrop_StreamlabsSystem.py
+++ b/MWO_SyncDrop_StreamlabsSystem.py
@@ -16,7 +16,7 @@ ScriptName = "Sync-Drop Countdown Script"
 Website = "https://www.dimensionv.de"
 Description = "Initiates a countdown on chat for sync-dropping, using the !syncdrop command"
 Creator = "Karubian"
-Version = "1.2.0"
+Version = "1.3.0"
 
 #---------------------------------------
 # Set Variables
@@ -163,12 +163,16 @@ def runCountDown(count, includeEU, includeNA, includeOC):
 		
     sendMessage("Initiating sync-drop with the following regions included:")
 
+    includedRegions = ""
+
     if(includeNA):
-        sendMessage("North America")
+        includedRegions = addRegion("North America", includedRegions)
     if(includeEU):
-        sendMessage("Europe")
+        includedRegions = addRegion("Europe", includedRegions)
     if(includeOC):
-        sendMessage("Oceanic")
+        includedRegions = addRegion("Oceanic", includedRegions)
+
+    sendMessage(includedRegions)
 
     sendMessage("Sync drop starts in:")
 
@@ -182,6 +186,12 @@ def runCountDown(count, includeEU, includeNA, includeOC):
        Parent.SendTwitchMessage("/subscribersoff")
     
     return
+
+def addRegion(region, regions):
+    if(regions != "" ):
+        regions += ", "
+    regions += region
+    return regions
 
 def showHelp():
     sendMessage("!syncdrop [<countDownTime>|<countDownTime> <regions>]")


### PR DESCRIPTION
Up until now, each region was send as a single message of its own. As there is a minimum delay of 2 seconds between each message (as enforced by the bot itself), this meant that in worst case, there was 6 seconds of waiting just to see the included regions.
With the changes of this PR, there's only 2 seconds, no matter if it's one, two or three regions selected, because there's only one single message containing all regions.